### PR TITLE
Fix for #8: Message length limitation

### DIFF
--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerAny2ClientCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerAny2ClientCheck.java
@@ -17,8 +17,8 @@ public class DevonArchitectureLayerAny2ClientCheck extends DevonArchitectureChec
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (!source.isLayerClient() && target.isLayerClient()) {
-      return "Code from any layer other than client ('" + source.toString() + "') shall not depend on client layer ('"
-          + target.toString() + "').";
+      return "Code from any layer other than client shall not depend on client layer. ('" + source.getComponent() + "."
+          + source.getLayer() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerBatch2DataaccessCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerBatch2DataaccessCheck.java
@@ -17,8 +17,8 @@ public class DevonArchitectureLayerBatch2DataaccessCheck extends DevonArchitectu
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isLayerBatch() && target.isLayerDataAccess()) {
-      return "Code from batch layer ('" + source.toString() + "') shall not depend on dataaccess layer ('"
-          + target.toString() + "').";
+      return "Code from batch layer shall not depend on dataaccess layer. ('" + source.getComponent() + "."
+          + source.getLayer() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerBatch2Logic4ComponentCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerBatch2Logic4ComponentCheck.java
@@ -19,8 +19,9 @@ public class DevonArchitectureLayerBatch2Logic4ComponentCheck extends DevonArchi
   protected String checkDependency(JavaType source, Component sourceComponent, JavaType target) {
 
     if (source.isLayerBatch() && target.isLayerLogic()) {
-      return "Code from batch layer ('" + source.toString()
-          + "') shall not depend on logic layer of a different component ('" + target.toString() + "').";
+      return "Code from batch layer shall not depend on logic layer of a different component. ('"
+          + source.getComponent() + "." + source.getLayer() + "' is dependent on '" + target.getComponent() + "."
+          + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerBatch2ServiceCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerBatch2ServiceCheck.java
@@ -17,8 +17,8 @@ public class DevonArchitectureLayerBatch2ServiceCheck extends DevonArchitectureC
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isLayerBatch() && target.isLayerService()) {
-      return "Code from batch layer ('" + source.toString() + "') shall not depend on service layer ('"
-          + target.toString() + "').";
+      return "Code from batch layer shall not depend on service layer. ('" + source.getComponent() + "."
+          + source.getLayer() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerClient2BatchCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerClient2BatchCheck.java
@@ -17,8 +17,8 @@ public class DevonArchitectureLayerClient2BatchCheck extends DevonArchitectureCh
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isLayerClient() && target.isLayerBatch()) {
-      return "Code from client layer ('" + source.toString() + "') shall not depend on batch layer ('"
-          + target.toString() + "').";
+      return "Code from client layer shall not depend on batch layer. ('" + source.getComponent() + "."
+          + source.getLayer() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerClient2DataaccessCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerClient2DataaccessCheck.java
@@ -17,8 +17,8 @@ public class DevonArchitectureLayerClient2DataaccessCheck extends DevonArchitect
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isLayerClient() && target.isLayerDataAccess()) {
-      return "Code from client layer ('" + source.toString() + "') shall not depend on dataaccess layer ('"
-          + target.toString() + "').";
+      return "Code from client layer shall not depend on dataaccess layer. ('" + source.getComponent() + "."
+          + source.getLayer() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerClient2LogicCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerClient2LogicCheck.java
@@ -17,8 +17,8 @@ public class DevonArchitectureLayerClient2LogicCheck extends DevonArchitectureCh
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isLayerClient() && target.isLayerLogic()) {
-      return "Code from client layer ('" + source.toString() + "') shall not depend on logic layer ('"
-          + target.toString() + "').";
+      return "Code from client layer shall not depend on logic layer. ('" + source.getComponent() + "."
+          + source.getLayer() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerCommon2AnyCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerCommon2AnyCheck.java
@@ -17,8 +17,8 @@ public class DevonArchitectureLayerCommon2AnyCheck extends DevonArchitectureChec
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isLayerCommon() && !target.isLayerCommon()) {
-      return "Code from common layer ('" + source.toString() + "') shall not depend on any other layer ('"
-          + target.toString() + "').";
+      return "Code from common layer shall not depend on any other layer. ('" + source.getComponent() + "."
+          + source.getLayer() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerDataaccess2Dataaccess4ComponentCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerDataaccess2Dataaccess4ComponentCheck.java
@@ -20,8 +20,9 @@ public class DevonArchitectureLayerDataaccess2Dataaccess4ComponentCheck extends 
 
     if (source.isLayerDataAccess() && target.isLayerDataAccess()
         && !isSameOrGeneralComponentWithSameOrCommonLayer(source, target)) {
-      return "Code from dataaccess layer ('" + source.toString()
-          + "') shall not depend on dataaccess layer of a different component ('" + target.toString() + "').";
+      return "Code from dataaccess layer shall not depend on dataaccess layer of a different component. ('"
+          + source.getComponent() + "." + source.getLayer() + "' is dependent on '" + target.getComponent() + "."
+          + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerDataaccess2LogicCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerDataaccess2LogicCheck.java
@@ -16,8 +16,8 @@ public class DevonArchitectureLayerDataaccess2LogicCheck extends DevonArchitectu
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isLayerDataAccess() && target.isLayerLogic()) {
-      return "Dataaccess layer ('" + source.toString() + "') shall not depend on logic layer ('" + target.toString()
-          + "').";
+      return "Dataaccess layer shall not depend on logic layer. ('" + source.getComponent() + "." + source.getLayer()
+          + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerDataaccess2ServiceCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerDataaccess2ServiceCheck.java
@@ -17,8 +17,8 @@ public class DevonArchitectureLayerDataaccess2ServiceCheck extends DevonArchitec
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isLayerDataAccess() && target.isLayerService()) {
-      return "Code from dataaccess layer ('" + source.toString() + "') shall not depend on service layer ('"
-          + target.toString() + "').";
+      return "Code from dataaccess layer shall not depend on service layer. ('" + source.getComponent() + "."
+          + source.getLayer() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerLogic2Dataaccess4ComponentCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerLogic2Dataaccess4ComponentCheck.java
@@ -22,8 +22,9 @@ public class DevonArchitectureLayerLogic2Dataaccess4ComponentCheck extends Devon
       if (target.toString().equals("com.devonfw.module.jpa.dataaccess.api.RevisionMetadata")) {
         return null; // specific exclusion for unclean packaging
       }
-      return "Code from logic layer ('" + source.toString()
-          + "') shall not depend on dataaccess layer of a different component ('" + target.toString() + "').";
+      return "Code from logic layer shall not depend on dataaccess layer of a different component. ('"
+          + source.getComponent() + "." + source.getLayer() + "' is dependent on '" + target.getComponent() + "."
+          + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerLogic2ServiceCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerLogic2ServiceCheck.java
@@ -17,8 +17,8 @@ public class DevonArchitectureLayerLogic2ServiceCheck extends DevonArchitectureC
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isLayerLogic() && target.isLayerService() && isSameRootApplication(source, target)) {
-      return "Code from logic layer ('" + source.toString() + "') shall not depend on service layer ('"
-          + target.toString() + "').";
+      return "Code from logic layer shall not depend on service layer. ('" + source.getComponent() + "."
+          + source.getLayer() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerService2BatchCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerService2BatchCheck.java
@@ -17,8 +17,8 @@ public class DevonArchitectureLayerService2BatchCheck extends DevonArchitectureC
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isLayerService() && target.isLayerBatch()) {
-      return "Code from service layer ('" + source.toString() + "') shall not depend on batch layer ('"
-          + target.toString() + "').";
+      return "Code from service layer shall not depend on batch layer. ('" + source.getComponent() + "."
+          + source.getLayer() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerService2DataaccessCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerService2DataaccessCheck.java
@@ -20,8 +20,8 @@ public class DevonArchitectureLayerService2DataaccessCheck extends DevonArchitec
       if (target.toString().equals("com.devonfw.module.jpa.dataaccess.api.RevisionMetadata")) {
         return null; // specific exclusion for unclean packaging
       }
-      return "Code from service layer ('" + source.toString() + "') shall not depend on dataacssess layer ('"
-          + target.toString() + "').";
+      return "Code from service layer shall not depend on dataaccess layer. ('" + source.getComponent() + "."
+          + source.getLayer() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerService2Logic4ComponentCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerService2Logic4ComponentCheck.java
@@ -19,8 +19,9 @@ public class DevonArchitectureLayerService2Logic4ComponentCheck extends DevonArc
   protected String checkDependency(JavaType source, Component sourceComponent, JavaType target) {
 
     if (source.isLayerService() && target.isLayerLogic()) {
-      return "Code from service layer of a component ('" + source.toString()
-          + "') shall not depend on logic layer of a different component ('" + target.toString() + "').";
+      return "Code from service layer of a component shall not depend on logic layer of a different component. ('"
+          + source.getComponent() + "." + source.getLayer() + "' is dependent on '" + target.getComponent() + "."
+          + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerService2Service4ComponentCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureLayerService2Service4ComponentCheck.java
@@ -19,8 +19,9 @@ public class DevonArchitectureLayerService2Service4ComponentCheck extends DevonA
   protected String checkDependency(JavaType source, Component sourceComponent, JavaType target) {
 
     if (source.isLayerService() && target.isLayerService()) {
-      return "Code from service layer ('" + source.toString()
-          + "') shall not depend on service layer of a different component ('" + target.toString() + "').";
+      return "Code from service layer shall not depend on service layer of a different component. ('"
+          + source.getComponent() + "." + source.getLayer() + "' is dependent on '" + target.getComponent() + "."
+          + target.getLayer() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeApi2Base4ComponentPartCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeApi2Base4ComponentPartCheck.java
@@ -18,8 +18,9 @@ public class DevonArchitectureScopeApi2Base4ComponentPartCheck extends DevonArch
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isScopeApi() && target.isScopeBase() && !isSameComponentPart(source, target)) {
-      return "Code from api scope ('" + source.toString()
-          + "') shall not depend on base scope of other component part ('" + target.toString() + "').";
+      return "Code from api scope shall not depend on base scope of another component part. ('" + source.getComponent()
+          + "." + source.getLayer() + "." + source.getScope() + "' is dependent on '" + target.getComponent() + "."
+          + target.getLayer() + "." + target.getScope() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeApi2BaseCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeApi2BaseCheck.java
@@ -17,8 +17,9 @@ public class DevonArchitectureScopeApi2BaseCheck extends DevonArchitectureCheck 
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isScopeApi() && target.isScopeBase() && isSameComponentPart(source, target)) {
-      return "Code from api scope ('" + source.toString() + "') shall not depend on base scope ('" + target.toString()
-          + "').";
+      return "Code from api scope shall not depend on base scope. ('" + source.getComponent() + "." + source.getLayer()
+          + "." + source.getScope() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "."
+          + target.getScope() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeApi2ImplCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeApi2ImplCheck.java
@@ -17,8 +17,9 @@ public class DevonArchitectureScopeApi2ImplCheck extends DevonArchitectureCheck 
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isScopeApi() && target.isScopeImpl()) {
-      return "Code from api scope ('" + source.toString() + "') shall not depend on impl scope ('" + target.toString()
-          + "').";
+      return "Code from api scope shall not depend on impl scope. ('" + source.getComponent() + "." + source.getLayer()
+          + "." + source.getScope() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "."
+          + target.getScope() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeBase2Base4ComponentPartCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeBase2Base4ComponentPartCheck.java
@@ -19,8 +19,9 @@ public class DevonArchitectureScopeBase2Base4ComponentPartCheck extends DevonArc
 
     if (source.isScopeBase() && target.isScopeBase() && !isSameComponentPart(source, target)
         && !isSameOrGeneralComponentWithSameOrCommonLayer(source, target)) {
-      return "Code from base scope ('" + source.toString()
-          + "') shall not depend on base scope of other component part ('" + target.toString() + "').";
+      return "Code from base scope shall not depend on base scope of other component part. ('" + source.getComponent()
+          + "." + source.getLayer() + "." + source.getScope() + "' is dependent on '" + target.getComponent() + "."
+          + target.getLayer() + "." + target.getScope() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeBase2Impl4ComponentPartCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeBase2Impl4ComponentPartCheck.java
@@ -18,8 +18,9 @@ public class DevonArchitectureScopeBase2Impl4ComponentPartCheck extends DevonArc
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isScopeBase() && target.isScopeImpl() && !isSameComponentPart(source, target)) {
-      return "Code from base scope ('" + source.toString()
-          + "') shall not depend on impl scope of other component part ('" + target.toString() + "').";
+      return "Code from base scope shall not depend on impl scope of other component part. ('" + source.getComponent()
+          + "." + source.getLayer() + "." + source.getScope() + "' is dependent on '" + target.getComponent() + "."
+          + target.getLayer() + "." + target.getScope() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeBase2ImplCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeBase2ImplCheck.java
@@ -17,8 +17,9 @@ public class DevonArchitectureScopeBase2ImplCheck extends DevonArchitectureCheck
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isScopeBase() && target.isScopeImpl() && isSameComponentPart(source, target)) {
-      return "Code from base scope ('" + source.toString() + "') shall not depend on impl scope ('" + target.toString()
-          + "').";
+      return "Code from base scope shall not depend on impl scope. ('" + source.getComponent() + "." + source.getLayer()
+          + "." + source.getScope() + "' is dependent on '" + target.getComponent() + "." + target.getLayer() + "."
+          + target.getScope() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeImpl2Base4ComponentPartCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeImpl2Base4ComponentPartCheck.java
@@ -17,9 +17,11 @@ public class DevonArchitectureScopeImpl2Base4ComponentPartCheck extends DevonArc
   @Override
   protected String checkDependency(JavaType source, JavaType target) {
 
-    if (source.isScopeImpl() && target.isScopeBase() && !isSameOrGeneralComponentWithSameOrCommonLayer(source, target)) {
-      return "Code from impl scope ('" + source.toString()
-          + "') shall not depend on base scope of other component part ('" + target.toString() + "').";
+    if (source.isScopeImpl() && target.isScopeBase()
+        && !isSameOrGeneralComponentWithSameOrCommonLayer(source, target)) {
+      return "Code from impl scope shall not depend on base scope of other component part. ('" + source.getComponent()
+          + "." + source.getLayer() + "." + source.getScope() + "' is dependent on '" + target.getComponent() + "."
+          + target.getLayer() + "." + target.getScope() + "')";
     }
     return null;
   }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeImpl2Impl4ComponentPartCheck.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/check/DevonArchitectureScopeImpl2Impl4ComponentPartCheck.java
@@ -18,8 +18,9 @@ public class DevonArchitectureScopeImpl2Impl4ComponentPartCheck extends DevonArc
   protected String checkDependency(JavaType source, JavaType target) {
 
     if (source.isScopeImpl() && target.isScopeImpl() && !isSameComponentPart(source, target)) {
-      return "Code from impl scope ('" + source.toString()
-          + "') shall not depend on impl scope of other component part ('" + target.toString() + "').";
+      return "Code from impl scope shall not depend on impl scope of other component part. ('" + source.getComponent()
+          + "." + source.getLayer() + "." + source.getScope() + "' is dependent on '" + target.getComponent() + "."
+          + target.getLayer() + "." + target.getScope() + "')";
     }
     return null;
   }


### PR DESCRIPTION
Length of issue messages was too long. Shortened displayed path of source and target in the issue messages thrown by layer & scope dependency checks. New design of issue messages: 
![new_issue_msg_design](https://user-images.githubusercontent.com/49903872/65685746-ff878880-e062-11e9-907d-03ea61f2c910.PNG)
Now only the component name and the layer where the issue occurs is shown. 
In case of a scope dependency issue, the scope is displayed as well.
